### PR TITLE
fix: pre-beta security hardening — 3 issues

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -69,9 +69,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const { user: authUser } = await authService.handleGoogleCallback();
 
       // If there's a pending invite token, accept it now.
-      const pendingToken = localStorage.getItem('pendingInviteToken');
+      const pendingToken = sessionStorage.getItem('pendingInviteToken');
       if (pendingToken) {
-        localStorage.removeItem('pendingInviteToken');
+        sessionStorage.removeItem('pendingInviteToken');
         try {
           await api.post('/api/family/invite/accept', { token: pendingToken });
           await authService.logout();

--- a/client/src/pages/AcceptInvite.tsx
+++ b/client/src/pages/AcceptInvite.tsx
@@ -65,7 +65,7 @@ const AcceptInvite: React.FC = () => {
 
     const handleSignInAndAccept = () => {
         // Store token so AuthContext can pick it up after OAuth callback
-        localStorage.setItem('pendingInviteToken', token);
+        sessionStorage.setItem('pendingInviteToken', token);
         loginWithGoogle();
     };
 

--- a/server/src/controllers/emailIngestController.ts
+++ b/server/src/controllers/emailIngestController.ts
@@ -32,7 +32,7 @@ const INGEST_FROM = { name: 'kinroo.ai', address: 'add@kinroo.ai' };
 // ── Webhook secret check ───────────────────────────────────────────────────────
 function validateWebhookSecret(req: Request): boolean {
     const secret = process.env.SENDGRID_INBOUND_WEBHOOK_SECRET;
-    if (!secret) return true;
+    if (!secret) return false; // fail closed — secret must be configured
     return req.query['secret'] === secret;
 }
 

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -216,6 +216,7 @@ export class EventController {
     public getEventById = async (req: Request, res: Response): Promise<Response> => {
         try {
             const { id } = req.params;
+            if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
             const userId = effectiveUserId(req);
             const { timezone } = req.query;
 
@@ -593,6 +594,7 @@ export class EventController {
     public deleteEvent = async (req: Request, res: Response): Promise<Response> => {
         try {
             const { id } = req.params;
+            if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
             const userId = effectiveUserId(req);
             const recurringScope = req.query.recurringScope as 'this' | 'future' | 'all' | undefined;
             const occurrenceDate = req.query.occurrenceDate as string | undefined;


### PR DESCRIPTION
- AcceptInvite + AuthContext: move pendingInviteToken from localStorage
  to sessionStorage (XSS-inaccessible after tab close; same-tab flow
  still works across OAuth redirect)

- emailIngestController: fail closed when SENDGRID_INBOUND_WEBHOOK_SECRET
  is unset (was `return true`, allowing unauthenticated ingest)

- eventController: add explicit 401 checks to getEventById and deleteEvent
  (defense-in-depth; app-level authenticateJWT already protects these,
  but consistency with rest of codebase)

https://claude.ai/code/session_012FnS9B72dCnZZATZq65iw2